### PR TITLE
fix: update changelog workflow permissions

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Get PR title and body
         id: pr-info
@@ -84,16 +85,19 @@ jobs:
           git config --local user.name "github-actions[bot]"
           
           # Create branch, commit and push
-          git checkout -b bot/update-changelog-v${NEW_VERSION}
+          BRANCH_NAME="bot/update-changelog-v${NEW_VERSION}"
+          git checkout -b "$BRANCH_NAME"
           git add CHANGELOG.md
           git commit -m "docs: update changelog for v${NEW_VERSION}"
-          git push origin bot/update-changelog-v${NEW_VERSION}
           
-          # Create PR
+          # Force push in case branch exists
+          git push -f origin "$BRANCH_NAME"
+          
+          # Create PR using GitHub CLI
           gh pr create \
             --title "docs: update changelog for v${NEW_VERSION}" \
             --body "Automated changelog update for version ${NEW_VERSION}" \
             --base main \
-            --head bot/update-changelog-v${NEW_VERSION}
+            --head "$BRANCH_NAME" || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           
       - name: Get PR title and body
         id: pr-info
@@ -100,4 +100,4 @@ jobs:
             --base main \
             --head "$BRANCH_NAME" || true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This project uses an automated changelog workflow that:
 - Determines change type from PR title (feat, fix, docs, etc.)
 - Increments version number automatically
 - Creates a new PR with changelog updates
+- Follows [Keep a Changelog](https://keepachangelog.com/) format
 
 ### Automated Releases
 


### PR DESCRIPTION
Use PAT_TOKEN instead of GITHUB_TOKEN for better permissions in the changelog workflow.

- Updates checkout action token
- Updates GitHub CLI token
- Enables PR creation from workflow